### PR TITLE
Disable "MTHC1" instruction for LS232.

### DIFF
--- a/arch/mips/kernel/r4k_switch.S
+++ b/arch/mips/kernel/r4k_switch.S
@@ -240,7 +240,7 @@ LEAF(_init_fpu)
 	mtc1	t1, $f30
 	mtc1	t1, $f31
 
-#ifdef CONFIG_CPU_MIPS32_R2
+#if defined(CONFIG_CPU_MIPS32_R2) && !defined(CONFIG_CPU_LOONGSON1)
 	.set    push
 	.set    mips32r2
 	.set	fp=64
@@ -280,7 +280,7 @@ LEAF(_init_fpu)
 	mthc1   t1, $f30
 	mthc1   t1, $f31
 1:	.set    pop
-#endif /* CONFIG_CPU_MIPS32_R2 */
+#endif /* defined(CONFIG_CPU_MIPS32_R2) && !defined(CONFIG_CPU_LOONGSON1) */
 #else
 	.set	arch=r4000
 	dmtc1	t1, $f0


### PR DESCRIPTION
LS232 is the CPU core (microarchitecture) of Loongson 1A/1B/1C.

According to "LS232用户手册 (LS232 User Manual)",
LS232 lacks "MTHC1" instruction.

Signed-off-by: 谢致邦 (XIE Zhibang) <Yeking@Red54.com>