### PR TITLE
Set loongson1 to MIPS32R1.

### DIFF
--- a/arch/mips/Kconfig
+++ b/arch/mips/Kconfig
@@ -302,7 +302,6 @@ config MACH_LOONGSON1
 	bool "Loongson 1 family of machines"
 	select CPU_LOONGSON1
 	select SYS_HAS_CPU_MIPS32_R1
-	select SYS_HAS_CPU_MIPS32_R2
 	select SYS_SUPPORTS_ZBOOT
 	select ARCH_REQUIRE_GPIOLIB
 	help

--- a/arch/mips/loongson1/Platform
+++ b/arch/mips/loongson1/Platform
@@ -1,14 +1,6 @@
-#cflags-$(CONFIG_CPU_LOONGSON1)	+= \
-#	$(call cc-option,-march=mips32r2,-mips32r2 -U_MIPS_ISA -D_MIPS_ISA=_MIPS_ISA_MIPS32) \
-#	-Wa,-mips32r2 -Wa,--trap
-
-cflags-$(CONFIG_CPU_MIPS32_R1)	+= \
+cflags-$(CONFIG_CPU_LOONGSON1)	+= \
 	$(call cc-option,-march=mips32,-mips32 -U_MIPS_ISA -D_MIPS_ISA=_MIPS_ISA_MIPS32) \
 	-Wa,-mips32 -Wa,--trap
-
-cflags-$(CONFIG_CPU_MIPS32_R2)	+= \
-	$(call cc-option,-march=mips32r2,-mips32r2 -U_MIPS_ISA -D_MIPS_ISA=_MIPS_ISA_MIPS32) \
-	-Wa,-mips32r2 -Wa,--trap
 
 platform-$(CONFIG_MACH_LOONGSON1)	+= loongson1/
 cflags-$(CONFIG_MACH_LOONGSON1)		+= -I$(srctree)/arch/mips/include/asm/mach-loongson1


### PR DESCRIPTION
Don't want to merge #2 and #3 ?

It's okay, just disable MIPS32R2 for LS232.

Get this thing done once and for ever.

不想合并 #2 和 #3 ？

没问题，为LS232禁用MIPS32R2就好了。

一劳永逸。